### PR TITLE
Install constellate client from package index.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+constellate-client
 requests
 pandas
 gensim==3.8.3

--- a/start
+++ b/start
@@ -2,14 +2,4 @@
 
 python3 -m nltk.downloader stopwords wordnet
 
-url=https://raw.githubusercontent.com/ithaka/tdm-notebooks/master/src/tdm_client.py
-
-rm -rf tdm_client.py
-wget $url
-
-cd /tmp
-cp ~/tdm_client.py .
-python3 tdm_client.py install
-cd -
-
 exec "$@"


### PR DESCRIPTION
Hi @jasf-, 

We have made the tdm_client (now called just constellate) installable via the Python package index. This change will install it from there. `import tdm_client` still works just fine but the preferred way moving forward will be `import constellate`. 